### PR TITLE
21 authenticate websocket connections via jwt

### DIFF
--- a/src/controller/auth.controller.ts
+++ b/src/controller/auth.controller.ts
@@ -189,3 +189,8 @@ export const refresh = async (req: Request, res: Response) => {
         res.status(401).json({ message: "Invalid refresh token" });
     }
 }
+
+export const getToken = async (req: AuthRequest, res: Response) => {
+    const accessToken = req.cookies.access_token;
+    res.json({ access_token: accessToken });
+};

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -1,5 +1,13 @@
 import { Router } from "express";
-import { url, callback, verify, logout, csrfToken, refresh } from "../controller/auth.controller";
+import {
+  url,
+  callback,
+  verify,
+  logout,
+  csrfToken,
+  refresh,
+  getToken,
+} from "../controller/auth.controller";
 import { authenticated } from "../middleware/middleware";
 import { validateCsrf } from "../middleware/middleware";
 
@@ -11,4 +19,6 @@ router.get("/google/verify", authenticated, verify);
 router.post("/google/logout", authenticated, validateCsrf, logout);
 router.get("/csrf", csrfToken);
 router.post("/google/refresh", refresh);
+router.get("/token", authenticated, getToken);
+
 export default router;

--- a/src/services/websocket.service.ts
+++ b/src/services/websocket.service.ts
@@ -1,5 +1,15 @@
 import { WebSocket } from "ws";
 
+// ─── Authenticated WebSocket ──────────────────────────────────────────────────
+
+export interface AuthenticatedWebSocket extends WebSocket {
+  user: {
+    userId: string;
+    email: string;
+    name: string;
+  };
+}
+
 // ─── Message Types ────────────────────────────────────────────────────────────
 
 export const MessageType = {
@@ -21,13 +31,13 @@ export interface WebSocketMessage {
 
 // ─── Client Tracking ──────────────────────────────────────────────────────────
 
-const clients = new Set<WebSocket>();
+const clients = new Set<AuthenticatedWebSocket>();
 
-export function addClient(ws: WebSocket): void {
+export function addClient(ws: AuthenticatedWebSocket): void {
   clients.add(ws);
 }
 
-export function removeClient(ws: WebSocket): void {
+export function removeClient(ws: AuthenticatedWebSocket): void {
   clients.delete(ws);
 }
 

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -1,5 +1,8 @@
 import { Server as HttpServer } from "http";
 import { WebSocketServer, WebSocket } from "ws";
+import { parse as parseUrl } from "url";
+import { IncomingMessage } from "http";
+import jwt from "jsonwebtoken";
 import {
   addClient,
   removeClient,
@@ -10,9 +13,30 @@ import {
 export function initWebSocket(server: HttpServer): WebSocketServer {
   const wss = new WebSocketServer({ server });
 
-  wss.on("connection", (ws: WebSocket) => {
-    console.log("WebSocket client connected");
-    addClient(ws);
+  wss.on("connection", (ws: WebSocket, request: IncomingMessage) => {
+    try {
+      const url = parseUrl(request.url || "", true);
+      const token = url.query.token as string;
+
+      if (!token) {
+        ws.close(4001, "Unauthorized: Missing token");
+        console.log("WebSocket connection rejected: No token provided");
+        return;
+      }
+
+      const payload = jwt.verify(token, process.env.JWT_SECRET!) as {
+        userId: string;
+        email: string;
+        name: string;
+      };
+
+      (ws as any).user = payload;
+      console.log(`WebSocket authenticated: ${payload.email}`);
+    } catch (error) {
+      ws.close(4001, "Unauthorized: Invalid or expired token");
+      console.log("WebSocket connection rejected: Token verification failed");
+      return;
+    }
 
     ws.send(
       JSON.stringify({
@@ -20,6 +44,8 @@ export function initWebSocket(server: HttpServer): WebSocketServer {
         message: "Connected to Kanban WebSocket server",
       }),
     );
+
+    addClient(ws);
 
     ws.on("message", (data) => {
       console.log("WebSocket message received:", data.toString());

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -4,6 +4,7 @@ import { parse as parseUrl } from "url";
 import { IncomingMessage } from "http";
 import jwt from "jsonwebtoken";
 import {
+  AuthenticatedWebSocket,
   addClient,
   removeClient,
   isValidMessage,
@@ -30,7 +31,7 @@ export function initWebSocket(server: HttpServer): WebSocketServer {
         name: string;
       };
 
-      (ws as any).user = payload;
+      (ws as AuthenticatedWebSocket).user = payload;
       console.log(`WebSocket authenticated: ${payload.email}`);
     } catch (error) {
       ws.close(4001, "Unauthorized: Invalid or expired token");
@@ -45,7 +46,7 @@ export function initWebSocket(server: HttpServer): WebSocketServer {
       }),
     );
 
-    addClient(ws);
+    addClient(ws as AuthenticatedWebSocket);
 
     ws.on("message", (data) => {
       console.log("WebSocket message received:", data.toString());
@@ -77,12 +78,12 @@ export function initWebSocket(server: HttpServer): WebSocketServer {
 
     ws.on("close", () => {
       console.log("WebSocket client disconnected");
-      removeClient(ws);
+      removeClient(ws as AuthenticatedWebSocket);
     });
 
     ws.on("error", (error) => {
       console.error("WebSocket error:", error);
-      removeClient(ws);
+      removeClient(ws as AuthenticatedWebSocket);
     });
   });
 

--- a/test-websocket-auth.js
+++ b/test-websocket-auth.js
@@ -1,0 +1,205 @@
+const http = require("http");
+const WebSocket = require("ws");
+const net = require("net");
+
+const BASE_URL = "http://localhost:8000";
+const WS_URL = "ws://localhost:8000";
+
+/**
+ * Helper: Make HTTP request and return cookies
+ */
+function makeRequest(options) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(options, (res) => {
+      let data = "";
+      const cookies = res.headers["set-cookie"] || [];
+
+      res.on("data", (chunk) => {
+        data += chunk;
+      });
+
+      res.on("end", () => {
+        resolve({
+          status: res.statusCode,
+          data: data ? JSON.parse(data) : null,
+          cookies,
+          headers: res.headers,
+        });
+      });
+    });
+
+    req.on("error", reject);
+
+    if (options.body) {
+      req.write(JSON.stringify(options.body));
+    }
+
+    req.end();
+  });
+}
+
+/**
+ * Main test function
+ */
+async function testWebSocketAuth() {
+  console.log("🧪 Starting WebSocket JWT Authentication Test\n");
+
+  try {
+    // Step 1: Check if server is running
+    console.log("1️⃣  Checking if server is running...");
+    const healthCheck = await makeRequest({
+      hostname: "localhost",
+      port: 8000,
+      path: "/",
+      method: "GET",
+    });
+
+    if (healthCheck.status !== 200) {
+      throw new Error(`Server not responding. Status: ${healthCheck.status}`);
+    }
+    console.log("✅ Server is running\n");
+
+    // Step 2: Test unauthenticated WebSocket connection (should be rejected)
+    console.log(
+      "2️⃣  Testing unauthenticated WebSocket connection (should fail)...",
+    );
+    await new Promise((resolve, reject) => {
+      const ws = new WebSocket(`${WS_URL}`);
+      let opened = false;
+
+      ws.on("open", () => {
+        console.log("  ⚠️  Connection opened, waiting for close/error...");
+        opened = true;
+      });
+
+      ws.on("close", (code, reason) => {
+        if (code === 4001 && reason.includes("Missing token")) {
+          console.log(`✅ Correctly rejected with code 4001: "${reason}"\n`);
+          resolve();
+        } else if (code === 4001) {
+          console.log(`✅ Rejected with code 4001 (JWT issue): "${reason}"\n`);
+          resolve();
+        } else {
+          reject(
+            new Error(
+              `❌ FAIL: Wrong close code or reason. Code: ${code}, Reason: ${reason}`,
+            ),
+          );
+        }
+      });
+
+      ws.on("error", (error) => {
+        console.log(`✅ Connection error as expected: ${error.message}\n`);
+        resolve();
+      });
+
+      setTimeout(() => {
+        if (opened) {
+          reject(
+            new Error(
+              "❌ FAIL: Unauthenticated connection was accepted and not closed!",
+            ),
+          );
+        } else {
+          reject(new Error("Timeout waiting for connection response"));
+        }
+      }, 3000);
+    });
+
+    // Step 3: Test invalid token rejection
+    console.log("3️⃣  Testing invalid token rejection...");
+    await new Promise((resolve, reject) => {
+      const ws = new WebSocket(`${WS_URL}?token=invalid-token-xyz`);
+      let opened = false;
+
+      ws.on("open", () => {
+        console.log("  ⚠️  Connection opened, waiting for close/error...");
+        opened = true;
+      });
+
+      ws.on("close", (code, reason) => {
+        if (code === 4001 && reason.includes("Invalid or expired token")) {
+          console.log(
+            `✅ Correctly rejected invalid token with code 4001: "${reason}"\n`,
+          );
+          resolve();
+        } else if (code === 4001) {
+          console.log(`✅ Rejected with code 4001: "${reason}"\n`);
+          resolve();
+        } else {
+          reject(
+            new Error(
+              `❌ FAIL: Wrong close code or reason. Code: ${code}, Reason: ${reason}`,
+            ),
+          );
+        }
+      });
+
+      ws.on("error", (error) => {
+        console.log(`✅ Invalid token error as expected: ${error.message}\n`);
+        resolve();
+      });
+
+      setTimeout(() => {
+        if (opened) {
+          reject(
+            new Error(
+              "❌ FAIL: Invalid token connection was accepted and not closed!",
+            ),
+          );
+        } else {
+          reject(new Error("Timeout waiting for connection response"));
+        }
+      }, 3000);
+    });
+
+    // Step 4: Test that /auth/token requires authentication
+    console.log("4️⃣  Testing that /auth/token requires authentication...");
+    const unauthTokenResponse = await makeRequest({
+      hostname: "localhost",
+      port: 8000,
+      path: "/auth/token",
+      method: "GET",
+    });
+
+    if (unauthTokenResponse.status === 401) {
+      console.log("✅ /auth/token correctly requires authentication (401)\n");
+    } else {
+      console.log(
+        `⚠️  /auth/token returned status ${unauthTokenResponse.status} (expected 401)\n`,
+      );
+    }
+
+    // Step 5: Generate a test JWT token (for manual testing or if you have test credentials)
+    console.log("5️⃣  For authenticated WebSocket testing:");
+    console.log("   a) Log in via Google OAuth in your browser");
+    console.log("   b) Then run this test again, OR");
+    console.log("   c) In browser console after login, run:\n");
+    console.log('      fetch("/auth/token", { credentials: "include" })');
+    console.log("        .then(r => r.json())");
+    console.log("        .then(({ access_token }) => {");
+    console.log(
+      "          const ws = new WebSocket(`ws://localhost:8000?token=${access_token}`);",
+    );
+    console.log(
+      '          ws.onopen = () => console.log("✅ WebSocket connected!");',
+    );
+    console.log(
+      '          ws.onmessage = (e) => console.log("Message:", JSON.parse(e.data));',
+    );
+    console.log(
+      '          ws.onclose = (e) => console.log("Closed:", e.code, e.reason);',
+    );
+    console.log("        })\n");
+
+    console.log(
+      "✨ Test completed successfully! All unauthenticated rejections working correctly.",
+    );
+    console.log("📝 See instructions above for full authenticated flow.\n");
+  } catch (error) {
+    console.error("❌ Test failed:", error.message);
+    process.exit(1);
+  }
+}
+
+testWebSocketAuth().catch(console.error);


### PR DESCRIPTION
- closes #21 
- JWT verification in WebSocket -> Parse + verify token from query param
-  AuthenticatedWebSocket interface -> Type safety for authenticated clients
- /auth/token endpoint -> This enabled the browser test to work