### PR TITLE
22 broadcast taskcreated event to all clients

### DIFF
--- a/public/ws-test.html
+++ b/public/ws-test.html
@@ -242,8 +242,21 @@
       }
 
       function connect() {
+        // Extract token from URL query parameter
+        const urlParams = new URLSearchParams(window.location.search);
+        const token = urlParams.get("token");
+
+        if (!token) {
+          appendLog(
+            "Error: No token provided in URL query parameter (?token=...)",
+            "log-error",
+          );
+          setStatus("Error: Missing token", "error");
+          return;
+        }
+
         // Server is running on localhost:8000, so connect the WebSocket directly there.
-        const url = "ws://localhost:8000";
+        const url = "ws://localhost:8000/?token=" + encodeURIComponent(token);
 
         appendLog("Connecting to " + url + "...", "log-info");
         ws = new WebSocket(url);

--- a/src/controller/task.controller.ts
+++ b/src/controller/task.controller.ts
@@ -1,9 +1,7 @@
 import { TaskService } from "../services/task.service";
 import { Response } from "express";
 import { AuthRequest } from "../middleware/middleware";
-
-// ─── WebSocket Integration (uncomment when ready) ────────────────────────────
-// import { broadcast } from "../services/websocket.service";
+import { broadcast, MessageType } from "../services/websocket.service";
 
 export const addTask = async (req: AuthRequest, res: Response) => {
   const task = req.body;
@@ -17,11 +15,11 @@ export const addTask = async (req: AuthRequest, res: Response) => {
     const result = await TaskService.add(task, userId);
 
     // ─── Broadcast to all connected WebSocket clients ────────────
-    // broadcast({
-    //     type: "TASK_CREATED",
-    //     payload: result,
-    //     timestamp: new Date().toISOString(),
-    // });
+    broadcast({
+      type: MessageType.TASK_CREATED,
+      payload: result,
+      timestamp: new Date().toISOString(),
+    });
 
     res.json(result);
   } catch (err: any) {

--- a/src/services/websocket.service.ts
+++ b/src/services/websocket.service.ts
@@ -13,7 +13,7 @@ export interface AuthenticatedWebSocket extends WebSocket {
 // ─── Message Types ────────────────────────────────────────────────────────────
 
 export const MessageType = {
-  TASK_CREATED: "TASK_CREATED",
+  TASK_CREATED: "task:created",
   TASK_UPDATED: "TASK_UPDATED",
   TASK_MOVED: "TASK_MOVED",
   TASK_DELETED: "TASK_DELETED",

--- a/task-broadcast.rest
+++ b/task-broadcast.rest
@@ -1,0 +1,14 @@
+### Get JWT Token
+GET http://localhost:5500
+Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxMDk3OTU0MTkzMjY0Nzc4MDk3NjMiLCJlbWFpbCI6Imtib3JiYW5vQHVwLmVkdS5waCIsIm5hbWUiOiJLaW50IExvdWlzZSBCb3JiYW5vIiwiaWF0IjoxNzczNjcyNzg4LCJleHAiOjE3NzM2NzM2ODh9.54u6B4oNBZnbl0D8P9Gks5YMOlE7U-iziqzqZ1t_t1g
+
+### Create Task (broadcasts to WebSocket clients)
+POST http://localhost:8000/task/add
+Content-Type: application/json
+Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxMDk3OTU0MTkzMjY0Nzc4MDk3NjMiLCJlbWFpbCI6Imtib3JiYW5vQHVwLmVkdS5waCIsIm5hbWUiOiJLaW50IExvdWlzZSBCb3JiYW5vIiwiaWF0IjoxNzczNjcyNzg4LCJleHAiOjE3NzM2NzM2ODh9.54u6B4oNBZnbl0D8P9Gks5YMOlE7U-iziqzqZ1t_t1g
+
+{
+  "title": "Test Task",
+  "details": "Testing broadcast",
+  "current_status": "todo"
+}


### PR DESCRIPTION
- closes #22 
- The acceptance criteria reference `POST /tasks`, but the actual implemented endpoint is `POST /task/add`. This implementation will use the existing endpoint without renaming. Team should be informed about this endpoint path discrepancy for documentation/API contract purposes.