### PR TITLE
task 18 (soft delete) & task 19 (request validation)

### DIFF
--- a/src/controller/task.controller.ts
+++ b/src/controller/task.controller.ts
@@ -59,3 +59,29 @@ export const updateTask = async (req: AuthRequest, res: Response) => {
     res.status(500).json({ error: err.message });
   }
 };
+
+export const deleteTask = async (req: AuthRequest, res: Response) => {
+  const { id } = req.body;
+  const userId = req.user?.userId;
+
+  if (!userId) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  try {
+    const result = await TaskService.softDelete(id, userId);
+
+    broadcast({
+      type: MessageType.TASK_DELETED,
+      payload: result,
+      timestamp: new Date().toISOString(),
+    });
+
+    res.status(200).json(result);
+  } catch (err: any) {
+    if (err.message === "Task not found") {
+      return res.status(404).json({ error: err.message });
+    }
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -1,0 +1,62 @@
+import { NextFunction, Response } from "express";
+import { AuthRequest } from "./middleware";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const isValidUUID = (id: string): boolean => UUID_REGEX.test(id);
+
+export const validateCreateTask = (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction,
+) => {
+  const { title, details, current_status } = req.body ?? {};
+
+  if (typeof title !== "string" || title.trim() === "") {
+    return res.status(400).json({ error: "Title is required" });
+  }
+
+  if (typeof current_status !== "string" || current_status.trim() === "") {
+    return res.status(400).json({ error: "Current status is required" });
+  }
+
+  req.body = { title, details, current_status };
+  next();
+};
+
+export const validateUpdateTask = (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction,
+) => {
+  const rawId = req.params.id;
+  const id = Array.isArray(rawId) ? rawId[0] : rawId;
+
+  if (!id || !isValidUUID(id)) {
+    return res.status(400).json({ error: "Invalid task ID format" });
+  }
+
+  const { title, details, current_status } = req.body ?? {};
+  req.body = { title, details, current_status };
+  next();
+};
+
+export const validateDeleteTask = (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction,
+) => {
+  const { id, deleted } = req.body ?? {};
+
+  if (typeof id !== "string" || !isValidUUID(id)) {
+    return res.status(400).json({ error: "Valid task ID is required" });
+  }
+
+  if (deleted !== true) {
+    return res.status(400).json({ error: "Field 'deleted' must be true" });
+  }
+
+  req.body = { id, deleted };
+  next();
+};

--- a/src/routes/task.routes.ts
+++ b/src/routes/task.routes.ts
@@ -1,10 +1,17 @@
 import { Router } from "express";
-import { addTask, updateTask } from "../controller/task.controller";
+import { addTask, deleteTask, updateTask } from "../controller/task.controller";
 import { authenticated } from "../middleware/middleware";
+import {
+	validateCreateTask,
+	validateDeleteTask,
+	validateUpdateTask,
+} from "../middleware/validation";
 
 const router = Router();
 
-router.post("/add", authenticated, addTask);
-router.patch("/:id", authenticated, updateTask);
+router.post("/add", authenticated, validateCreateTask, addTask);
+router.patch("/:id", authenticated, validateUpdateTask, updateTask);
+// TODO: Integrate into unified POST /tasks endpoint (task d)
+router.post("/delete", authenticated, validateDeleteTask, deleteTask);
 
 export default router;

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -45,4 +45,22 @@ export const TaskService = {
 
     return rows[0];
   },
+
+  softDelete: async (id: string, userId: string) => {
+    const { rows } = await pool.query(
+      `
+            UPDATE tasks
+            SET deleted_at = now()
+            WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL
+            RETURNING *;
+            `,
+      [id, userId],
+    );
+
+    if (rows.length === 0) {
+      throw new Error("Task not found");
+    }
+
+    return rows[0];
+  },
 };


### PR DESCRIPTION
- Implements soft-delete for tasks via POST /task/delete (sets deleted_at, enforces ownership, broadcasts TASK_DELETED)
- Adds validation middleware for all task endpoints:
- POST /task/add: requires non-empty title and current_status, strips unknown fields
- PATCH /task/:id: requires valid UUID param, strips unknown fields
- POST /task/delete: requires valid UUID id and deleted: true
- All validation errors return descriptive { error: "..." } responses

Notes
- Ownership enforced in SQL (404 if not found or not owned)
- TODO comment added for future unified POST /tasks integration