### PR TITLE
refactor: api, websocket, payload validation refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm run dev
 
 ### Frontend
 
-1. Open the `frontend` folder in VS Code
+1. Open the project folder in VS Code
 2. Right click `index.html` → **Open with Live Server**
 3. Frontend will be available at `http://localhost:5500/index.html`
 
@@ -73,10 +73,20 @@ Install the [REST Client extension](https://marketplace.visualstudio.com/items?i
 
 > ⚠️ Do **NOT** use the Google `id_token`. Only the `access_token` issued by this server works.
 
-### Example Request
+### Task API (Shared Board)
+
+All authenticated users access a team-wide shared board.
+
+- `GET /task` returns all non-deleted tasks.
+- `POST /task` is the single manage endpoint:
+  - create: send `title`, `details`, `current_status`
+  - update: send `id` plus one or more updatable fields
+  - soft-delete: send `id` and `isDelete: true`
+
+### Example Requests
 
 ```http
-POST http://localhost:8000/task/add
+POST http://localhost:8000/task
 Content-Type: application/json
 Cookie: access_token=<paste_access_token_here>
 
@@ -84,6 +94,28 @@ Cookie: access_token=<paste_access_token_here>
     "title": "Task 1",
     "details": "This is the description",
     "current_status": "doing"
+}
+```
+
+```http
+POST http://localhost:8000/task
+Content-Type: application/json
+Cookie: access_token=<paste_access_token_here>
+
+{
+        "id": "<task_uuid>",
+        "current_status": "done"
+}
+```
+
+```http
+POST http://localhost:8000/task
+Content-Type: application/json
+Cookie: access_token=<paste_access_token_here>
+
+{
+        "id": "<task_uuid>",
+        "isDelete": true
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "passport-google-oauth20": "^2.0.0",
         "passport-http": "^0.3.0",
         "pg": "^8.19.0",
-        "ws": "^8.19.0"
+        "ws": "^8.19.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.4.2",
@@ -4218,6 +4219,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "passport-google-oauth20": "^2.0.0",
     "passport-http": "^0.3.0",
     "pg": "^8.19.0",
-    "ws": "^8.19.0"
+    "ws": "^8.19.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.4.2",

--- a/src/controller/task.controller.ts
+++ b/src/controller/task.controller.ts
@@ -3,7 +3,9 @@ import { Response } from "express";
 import { AuthRequest } from "../middleware/middleware";
 import { broadcast, MessageType } from "../services/websocket.service";
 
-export const addTask = async (req: AuthRequest, res: Response) => {
+export const ManageTasks = async (req: AuthRequest, res: Response) => {
+  const taskId = req.body.id;
+  const isDelete = req.body.isDelete;
   const task = req.body;
   const userId = req.user?.userId;
 
@@ -12,50 +14,31 @@ export const addTask = async (req: AuthRequest, res: Response) => {
   }
 
   try {
-    const result = await TaskService.add(task, userId);
+    let result;
+    let messageType;
 
+    if (taskId && !isDelete) {
+      // ─── Update existing task ─────────────────────────────────────
+      result = await TaskService.update(taskId, task);
+      messageType = MessageType.TASK_UPDATED;
+    } else if (taskId && isDelete) {
+      // ─── Delete existing task ─────────────────────────────────────
+      result = await TaskService.delete(taskId);
+      messageType = MessageType.TASK_DELETED;
+    } else {
+      result = await TaskService.add(userId, task);
+      messageType = MessageType.TASK_CREATED;
+    }
+    
     // ─── Broadcast to all connected WebSocket clients ────────────
     broadcast({
-      type: MessageType.TASK_CREATED,
+      type: messageType,
       payload: result,
       timestamp: new Date().toISOString(),
     });
 
     res.json(result);
   } catch (err: any) {
-    res.status(500).json({ error: err.message });
-  }
-};
-
-export const updateTask = async (req: AuthRequest, res: Response) => {
-  const rawId = req.params.id;
-  const id = Array.isArray(rawId) ? rawId[0] : rawId;
-  const updates = req.body;
-  const userId = req.user?.userId;
-
-  if (!userId) {
-    return res.status(401).json({ error: "Unauthorized" });
-  }
-
-  if (!id) {
-    return res.status(400).json({ error: "Task ID is required" });
-  }
-
-  try {
-    const result = await TaskService.update(id, updates);
-
-    // ─── Broadcast to all connected WebSocket clients ────────────
-    broadcast({
-      type: MessageType.TASK_UPDATED,
-      payload: result,
-      timestamp: new Date().toISOString(),
-    });
-
-    res.status(200).json(result);
-  } catch (err: any) {
-    if (err.message === "Task not found") {
-      return res.status(404).json({ error: err.message });
-    }
     res.status(500).json({ error: err.message });
   }
 };
@@ -68,7 +51,7 @@ export const getAllTasks = async (req: AuthRequest, res: Response) => {
   }
 
   try {
-    const result = await TaskService.getAll(userId);
+    const result = await TaskService.getAll();
 
     // ─── Broadcast to all connected WebSocket clients ────────────
     broadcast({

--- a/src/middleware/validator.ts
+++ b/src/middleware/validator.ts
@@ -1,0 +1,28 @@
+import { NextFunction, Response } from "express";
+import { ZodError } from "zod";
+import { AuthRequest } from "./middleware";
+import { TaskSchema } from "../schema/TaskSchema";
+
+export const validateTaskPayload = (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const parsedPayload = TaskSchema.parse(req.body);
+    req.body = parsedPayload;
+    next();
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return res.status(400).json({
+        error: "Invalid task payload",
+        details: error.issues.map((issue) => ({
+          path: issue.path.join("."),
+          message: issue.message,
+        })),
+      });
+    }
+
+    return res.status(400).json({ error: "Invalid task payload" });
+  }
+};

--- a/src/routes/task.routes.ts
+++ b/src/routes/task.routes.ts
@@ -1,11 +1,12 @@
 import { Router } from "express";
-import { addTask, updateTask, getAllTasks } from "../controller/task.controller";
+import { ManageTasks, getAllTasks } from "../controller/task.controller";
 import { authenticated } from "../middleware/middleware";
+import { validateTaskPayload } from "../middleware/validator";
 
 const router = Router();
 
-router.post("/add", authenticated, addTask);
-router.patch("/:id", authenticated, updateTask);
-router.get("/getAll", authenticated, getAllTasks);
+router.get("/", authenticated, getAllTasks);
+router.post("/", authenticated, validateTaskPayload, ManageTasks);
+
 
 export default router;

--- a/src/schema/TaskSchema.ts
+++ b/src/schema/TaskSchema.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+const taskContentFields = {
+  title: z.string().min(1, "Title cannot be empty"),
+  details: z.string().min(1, "Details cannot be empty"),
+  current_status: z.string().min(1, "Current status cannot be empty"),
+};
+
+const deleteSchema = z
+  .object({
+    id: z.string().uuid("Task ID must be a valid UUID"),
+    isDelete: z.literal(true),
+  })
+  .strict();
+
+const updateSchema = z
+  .object({
+    id: z.string().uuid("Task ID must be a valid UUID"),
+    title: taskContentFields.title.optional(),
+    details: taskContentFields.details.optional(),
+    current_status: taskContentFields.current_status.optional(),
+  })
+  .strict()
+  .refine(
+    (data) =>
+      data.title !== undefined ||
+      data.details !== undefined ||
+      data.current_status !== undefined,
+    {
+      message:
+        "At least one of title, details, or current_status is required for update",
+    },
+  );
+
+const createSchema = z
+  .object({
+    ...taskContentFields,
+  })
+  .strict();
+
+export const TaskSchema = z.union([deleteSchema, updateSchema, createSchema]);
+
+export type TaskPayload = z.infer<typeof TaskSchema>;

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -13,7 +13,7 @@ interface UpdateTaskProps {
 }
 
 export const TaskService = {
-  add: async (task: TaskProps, userId: string) => {
+  add: async (userId: string, task: TaskProps) => {
     const { rows } = await pool.query(
       `
             INSERT INTO tasks (user_id, title, details, current_status)
@@ -25,7 +25,7 @@ export const TaskService = {
     return rows[0];
   },
 
-  update: async (id: string, updates: UpdateTaskProps) => {
+  update: async (TaskId: string, updates: UpdateTaskProps) => {
     const { rows } = await pool.query(
       `
             UPDATE tasks
@@ -37,7 +37,7 @@ export const TaskService = {
             WHERE id = $4 AND deleted_at IS NULL
             RETURNING *;
             `,
-      [updates.title, updates.details, updates.current_status, id],
+      [updates.title, updates.details, updates.current_status, TaskId],
     );
 
     if (rows.length === 0) {
@@ -47,15 +47,34 @@ export const TaskService = {
     return rows[0];
   },
 
-  getAll: async (userId: string) => {
+  delete: async (taskId: string) => {
+    const { rows } = await pool.query(
+      `
+            UPDATE tasks
+            SET deleted_at = NOW()
+            WHERE id = $1 AND deleted_at IS NULL
+            RETURNING *;
+            `,
+      [taskId],
+    );
+
+    if (rows.length === 0) {
+      throw new Error("Task not found");
+    }
+
+    return rows[0];
+  },
+
+
+  getAll: async () => {
     const { rows } = await pool.query(
       `
             SELECT *
             FROM tasks
-            WHERE user_id = $1 AND deleted_at IS NULL
+            WHERE deleted_at IS NULL
             ORDER BY created_at DESC;
             `,
-      [userId],
+      [],
     );
 
     return rows;

--- a/src/services/websocket.service.ts
+++ b/src/services/websocket.service.ts
@@ -16,8 +16,7 @@ export const MessageType = {
   TASK_CREATED: "task:created",
   TASK_UPDATED: "task:updated",
   TASK_GET_ALL: "task:getAll",
-  TASK_MOVED: "TASK_MOVED",
-  TASK_DELETED: "TASK_DELETED",
+  TASK_DELETED: "task:deleted",
 } as const;
 
 export type MessageTypeValue = (typeof MessageType)[keyof typeof MessageType];

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -64,7 +64,7 @@ export function initWebSocket(server: HttpServer): WebSocketServer {
           JSON.stringify({
             error: "Invalid message schema",
             expected: {
-              type: "TASK_CREATED | TASK_UPDATED | TASK_MOVED | TASK_DELETED",
+              type: "TASK_CREATED | TASK_UPDATED | TASK_GET_ALL | TASK_DELETED",
               payload: {},
               timestamp: "ISO 8601 string",
             },

--- a/task-broadcast.rest
+++ b/task-broadcast.rest
@@ -2,8 +2,8 @@
 GET http://localhost:5500
 Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxMDk3OTU0MTkzMjY0Nzc4MDk3NjMiLCJlbWFpbCI6Imtib3JiYW5vQHVwLmVkdS5waCIsIm5hbWUiOiJLaW50IExvdWlzZSBCb3JiYW5vIiwiaWF0IjoxNzczNjcyNzg4LCJleHAiOjE3NzM2NzM2ODh9.54u6B4oNBZnbl0D8P9Gks5YMOlE7U-iziqzqZ1t_t1g
 
-### Create Task (broadcasts to WebSocket clients)
-POST http://localhost:8000/task/add
+### Create Task (broadcasts task:created)
+POST http://localhost:8000/task
 Content-Type: application/json
 Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxMDk3OTU0MTkzMjY0Nzc4MDk3NjMiLCJlbWFpbCI6Imtib3JiYW5vQHVwLmVkdS5waCIsIm5hbWUiOiJLaW50IExvdWlzZSBCb3JiYW5vIiwiaWF0IjoxNzczNjcyNzg4LCJleHAiOjE3NzM2NzM2ODh9.54u6B4oNBZnbl0D8P9Gks5YMOlE7U-iziqzqZ1t_t1g
 
@@ -11,4 +11,24 @@ Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxMDk3OT
   "title": "Test Task",
   "details": "Testing broadcast",
   "current_status": "todo"
+}
+
+### Update Task (broadcasts task:updated)
+POST http://localhost:8000/task
+Content-Type: application/json
+Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxMDk3OTU0MTkzMjY0Nzc4MDk3NjMiLCJlbWFpbCI6Imtib3JiYW5vQHVwLmVkdS5waCIsIm5hbWUiOiJLaW50IExvdWlzZSBCb3JiYW5vIiwiaWF0IjoxNzczNjcyNzg4LCJleHAiOjE3NzM2NzM2ODh9.54u6B4oNBZnbl0D8P9Gks5YMOlE7U-iziqzqZ1t_t1g
+
+{
+  "id": "<task_uuid>",
+  "current_status": "doing"
+}
+
+### Soft Delete Task (broadcasts task:deleted)
+POST http://localhost:8000/task
+Content-Type: application/json
+Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxMDk3OTU0MTkzMjY0Nzc4MDk3NjMiLCJlbWFpbCI6Imtib3JiYW5vQHVwLmVkdS5waCIsIm5hbWUiOiJLaW50IExvdWlzZSBCb3JiYW5vIiwiaWF0IjoxNzczNjcyNzg4LCJleHAiOjE3NzM2NzM2ODh9.54u6B4oNBZnbl0D8P9Gks5YMOlE7U-iziqzqZ1t_t1g
+
+{
+  "id": "<task_uuid>",
+  "isDelete": true
 }

--- a/test.http
+++ b/test.http
@@ -20,7 +20,7 @@
 ###
 ### ======================================================
 
-POST http://localhost:8000/task/add
+POST http://localhost:8000/task
 Content-Type: application/json
 Cookie: access_token=<paste_access_token_here>
 
@@ -29,3 +29,27 @@ Cookie: access_token=<paste_access_token_here>
     "details": "This is the description",
     "current_status": "doing"
 }
+
+### Update task (single manage endpoint)
+POST http://localhost:8000/task
+Content-Type: application/json
+Cookie: access_token=<paste_access_token_here>
+
+{
+    "id": "<task_uuid>",
+    "current_status": "done"
+}
+
+### Soft delete task (single manage endpoint)
+POST http://localhost:8000/task
+Content-Type: application/json
+Cookie: access_token=<paste_access_token_here>
+
+{
+    "id": "<task_uuid>",
+    "isDelete": true
+}
+
+### Get all tasks (shared board)
+GET http://localhost:8000/task
+Cookie: access_token=<paste_access_token_here>


### PR DESCRIPTION
Implemented a single authenticated task management flow for a shared team board.

- Consolidated task operations into one endpoint: `POST /task` now handles create, update, and soft delete in task.controller.ts and task.routes.ts.
- Added Zod request validation with union schemas and middleware:
  - TaskSchema.ts
  - validator.ts
- Updated WebSocket broadcasts to emit action-specific events (`task:created`, `task:updated`, `task:deleted`) in task.controller.ts using message types from websocket.service.ts.
- Added `zod` dependency in package.json.
- Updated docs/examples to match the new API and shared-board behavior in README.md, test.http, and task-broadcast.rest.
- Verified with successful TypeScript build (`npm run build`).